### PR TITLE
Fix misleading webhooks' event example

### DIFF
--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -52,6 +52,8 @@ Each webhook event notification request contains a JSON object. The event JSON o
 
 `{"event_name": "...", "user_id"=..., "event_data": {...}}`
 
+The "user_id" points to the destination of the event.
+
 The structure of the "event_data" object varies depending on the type of event it is. For instance, if it is an "item:added" event notification,
 The "event_data" will represent the newly added item.
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -83,7 +83,7 @@ X-Todoist-Hmac-SHA256: UEEq9si3Vf9yRSrLthbpazbb69kP9+CZQ7fXmVyjhPs=
       "date_added": "Fri 26 Sep 2014 08:25:05 +0000",
       "id": 33511505,
       "content": "Task1",
-      "user_id": 1855589,
+      "user_id": 1234,
       "due_date_utc": null,
       "children": null,
       "priority": 1,


### PR DESCRIPTION
According to todoist Support(requests #93486), a webhook payload's `user_id` and `event_data.user_id` are all pointing to the event destination. Namely they have always same value. It is inconsistent with the example.