### PR TITLE
Remove token from every parameters table

### DIFF
--- a/source/includes/sync/v7/_activity.md
+++ b/source/includes/sync/v7/_activity.md
@@ -222,11 +222,10 @@ $ curl https://todoist.com/api/v7/activity/get \
 ]
 ```
 
-### Parameters
+### Properties
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 object_type *String* | No | Filters events by a specific object type.
 object_id *Integer* | No | Filters events by a specific object id, but only if the `object_type` has been also specified.
 event_type *String* | No | Filters events by a specific event type.

--- a/source/includes/sync/v7/_authorization.md
+++ b/source/includes/sync/v7/_authorization.md
@@ -4,8 +4,10 @@ In order to make authorized calls to Todoist APIs, your application must first
 obtain an access token from the users. This section describes the different ways
 of obtaining such a token.
 
-In case you're building an application and needs to access Todoist as an user,
-we encourage your application to use
+For the sake of simplicity we decided to not list the token on every parameter
+table but please note that the **token is required for every resource**.
+
+Note that we encourage your application to use
 the [OAuth](http://en.wikipedia.org/wiki/OAuth) protocol to obtain the access
 token from the user.
 
@@ -195,8 +197,8 @@ Access-Control-Allow-Origin: *
 
 ```python
 >>> import requests
->>> requests.post('https://todoist.com/api/v7/sync', 
-...               data={'token': '0123456789abcdef0123456789abcdef01234567'}, 
+>>> requests.post('https://todoist.com/api/v7/sync',
+...               data={'token': '0123456789abcdef0123456789abcdef01234567'},
 ...               headers={'Origin': 'https://example.com'}).headers
 
 {'Access-Control-Allow-Credentials': 'false', 'Access-Control-Allow-Origin': '*', <...>}

--- a/source/includes/sync/v7/_backups.md
+++ b/source/includes/sync/v7/_backups.md
@@ -36,9 +36,3 @@ $ curl https://todoist.com/api/v7/backups/get \
   ...
 ]
 ```
-
-### Parameters
-
-Parameter | Required | Description
---------- | -------- | -----------
-token *String* | Yes | The user's API token

--- a/source/includes/sync/v7/_business.md
+++ b/source/includes/sync/v7/_business.md
@@ -93,7 +93,7 @@ invitation object has an unique id and secret code. Anyone who knows this
 information, can activate invitation and join your business account. Invitation
 is deactivated at the moment it's accepted or rejected by receiver, or deleted
 manually by sender.
- 
+
 Invitation objects are not created (quietly skipped), if the invitation
 recipient is an existing Todoist user and this user already belongs to a
 business account.
@@ -109,7 +109,6 @@ The return value is a list of invitation objects.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 email_list *Array of Strings* | Yes | The emails of users which will be invited
 message *String* | No | Additional text which will be included to invitation welcome message
 
@@ -165,13 +164,12 @@ value.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 id *Integer* | Yes | The invitation id (a number).
 secret *String* | Yes | The secret fetched from the live notification (a string value).
 
 #### For the Sync API command:
 
-Parameter | Required | Description
+Command argument | Required | Description
 --------- | -------- | -----------
 invitation_id *Integer* | Yes | The invitation id (a number).
 invitation_secret *String* | Yes | The secret fetched from the live notification (a string value).
@@ -223,14 +221,12 @@ a successful return value.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 id *Integer* | Yes | The invitation id (a number).
 secret *String* | Yes | The secret fetched from the live notification (a string value).
-token *String* | No | The user's API token
 
 #### For the Sync API command:
 
-Parameter | Required | Description
+Command argument | Required | Description
 --------- | -------- | -----------
 invitation_id *Integer* | Yes | The invitation id (a number).
 invitation_secret *String* | Yes | The secret fetched from the live notification (a string value).

--- a/source/includes/sync/v7/_emails.md
+++ b/source/includes/sync/v7/_emails.md
@@ -29,7 +29,6 @@ Creates a new email address for an object, or gets an existing email.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 obj_type *String* | Yes | The object's type, one of `project`, `project_comments` or `item`.
 obj_id *Integer* | Yes | The object's id.
 
@@ -64,6 +63,5 @@ Disables an email address for an object.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 obj_type *String* | Yes | The object's type, one of `project`, `project_comments` or `item`.
 obj_id *Integer* | Yes | The object's id.

--- a/source/includes/sync/v7/_filters.md
+++ b/source/includes/sync/v7/_filters.md
@@ -51,11 +51,10 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 name *String* | Yes | The name of the filter.
 query *String* | Yes | The query to search for. [Examples of searches](https://todoist.com/Help/Filtering) can be found in the Todoist help page.
 color *Integer* | No | The color of the filter (between `0` and `7`, or between `0` and `12` for premium users).
@@ -85,11 +84,10 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 id *Integer or String (temp_id)* | Yes | The id of the filter.
 name *String* | No | The name of the filter
 query *String* | No | The query to search for. [Examples of searches](https://todoist.com/Help/Filtering) can be found in the Todoist help page.
@@ -120,11 +118,10 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 id *Integer or String (temp_id)* | Yes | The id of the filter.
 
 ## Update multiple orders
@@ -152,9 +149,8 @@ $ curl https://todoist.com/api/v7/sync \
 
 Update the orders of multiple filters at once.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 id_order_mapping *Object* | Yes | A dictionary, where a filter id is the key, and the order its value: `filter_id: order`.

--- a/source/includes/sync/v7/_items.md
+++ b/source/includes/sync/v7/_items.md
@@ -39,21 +39,21 @@ project_id *Integer* | Project that the task resides in
 content *String* | The text of the task
 date_string *String* | The date of the task, added in free form text, for example it can be `every day @ 10` (or `null` or an empty string if not set). Look at our reference to see [which formats are supported](https://todoist.com/Help/DatesTimes).
 date_lang *String* | The language of the `date_string` (valid languages are: `en`, `da`, `pl`, `zh`, `ko`, `de`, `pt`, `ja`, `it`, `fr`, `sv`, `ru`, `es`, `nl`).
-due_date_utc  *String* | The date of the task in the format `Mon 07 Aug 2006 12:34:56 +0000` (or `null` if not set). For all day task (i.e. task due "Today"), the time part will be set as xx:xx:59.
+due_date_utc *String* | The date of the task in the format `Mon 07 Aug 2006 12:34:56 +0000` (or `null` if not set). For all day task (i.e. task due "Today"), the time part will be set as xx:xx:59.
 priority *Integer* | The priority of the task (a number between `1` and `4`, `4` for very urgent and `1` for natural). <br>**Note**: Keep in mind that `very urgent` is the priority 1 on clients. So, `p1` will return `4` in the API.
 indent *Integer* | The indent of the task (a number between `1` and `4`, where `1` is top-level).
 item_order *Integer* | The order of the task inside a project (the smallest value would place the task at the top).
 day_order *Integer* | The order of the task inside the `Today` or `Next 7 days` view (a number, where the smallest value would place the task at the top).
-collapsed  *Integer* | Whether the task's sub-tasks are collapsed (where `1` is true and `0` is false).
+collapsed *Integer* | Whether the task's sub-tasks are collapsed (where `1` is true and `0` is false).
 labels *Array of Integer* | The tasks labels (a list of label ids such as `[2324,2525]`).
 assigned_by_uid *Integer* | The id of the user who assigns the current task. This makes sense for shared projects only. Accepts `0` or any user id from the list of project collaborators. If this value is unset or invalid, it will automatically be set up to your uid.
 responsible_uid *Integer* | The id of user who is responsible for accomplishing the current task. This makes sense for shared projects only. Accepts any user id from the list of project collaborators or `null` or an empty string to unset.
-checked  *Integer* | Whether the task is marked as completed (where `1` is true and `0` is false).
-in_history  *Integer* | Whether the task has been marked as completed and is marked to be moved to history, because all the child tasks of its parent are also marked as completed (where `1` is true and `0` is false)
-is_deleted  *Integer* | Whether the task is marked as deleted (where `1` is true and `0` is false).
-is_archived  *Integer* | Whether the task is marked as archived (where `1` is true and `0` is false).
-sync_id  *Integer* | A special id for shared tasks (a number or `null` if not set). Used internally and can be ignored.
-date_added  *String* | The date when the task was created.
+checked *Integer* | Whether the task is marked as completed (where `1` is true and `0` is false).
+in_history *Integer* | Whether the task has been marked as completed and is marked to be moved to history, because all the child tasks of its parent are also marked as completed (where `1` is true and `0` is false)
+is_deleted *Integer* | Whether the task is marked as deleted (where `1` is true and `0` is false).
+is_archived *Integer* | Whether the task is marked as archived (where `1` is true and `0` is false).
+sync_id *Integer* | A special id for shared tasks (a number or `null` if not set). Used internally and can be ignored.
+date_added *String* | The date when the task was created.
 
 
 ## Add an item
@@ -80,11 +80,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Add a new task to a project.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 content *String* | Yes | The text of the task.
 project_id  *Integer or String (temp id)* | No | The id of the project to add the task to (a number or a temp id).  By default the task is added to the user’s `Inbox` project.
 date_string *String* | No | The date of the task, added in free form text, for example it can be `every day @ 10` (or `null` or an empty string to unset). Look at our reference to see [which formats are supported](https://todoist.com/Help/DatesTimes).
@@ -124,12 +123,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Updates an item for the user related to the API credentials.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer or String (temp id)* | Yes | The id of the task.
-token *String* | Yes | The user's API token
 content *String* | No | The text of the task.
 date_string *String* | No | The date of the task, added in free form text, for example it can be `every day @ 10` (or `null` or an empty string to unset). Look at our reference to see [which formats are supported](https://todoist.com/Help/DatesTimes).
 date_lang  *String* | No | The language of the `date_string` (valid languages are: `en`, `da`, `pl`, `zh`, `ko`, `de`, `pt`, `ja`, `it`, `fr`, `sv`, `ru`, `es`, `nl`).
@@ -167,12 +165,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Delete an existing task.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 ids  *Array of Integer (id) or String (temp id)* | Yes | List of the ids of the tasks to delete.
-token *String* | Yes | The user's API token
 
 ## Move an item
 
@@ -198,11 +195,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Move a task from one project to another project.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 project_items *Object* | Yes | A JSON mapping telling Todoist where the items are currently found. From project ids to item ids, for example `{"1523":["9637423"]}`, where `1523` is the project id and `9637423` is the item id.
 to_project *Integer* | Yes | The project id that the tasks should be moved to, for example `1245`.
 
@@ -231,12 +227,11 @@ $ curl https://todoist.com/api/v7/sync \
 Complete tasks and optionally move them to history. See also `item_close` for a
 simplified version of the command.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 ids *Array of Integer or String (temp id)* | Yes | A JSON list of ids to complete (numbers or temp ids).
-token *String* | Yes | The user's API token
 force_history *Integer* | No | Whether these tasks should be moved to history (where `1` is true and `0` is false, and the default is `1`) This is useful when checking off sub tasks.
 
 ## Uncomplete items
@@ -263,12 +258,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Uncomplete tasks and move them to the active projects.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 ids *Array of Integer or String (temp id)*| Yes | A list of items to uncomplete.
-token *String* | Yes | The user's API token
 restore_state *Object* | No | A dictionary object, where the item id is the key, and its value is a list of four elements, whether the item is in history, whether it is checked, its order and indent - `item_id: [in_history, checked, item_order, indent]`
 
 
@@ -298,12 +292,11 @@ Complete a recurring task, and the reason why this is a special case is because
 we need to mark a recurring completion (and using `item_update` won't do
 this). See also `item_close` for a simplified version of the command.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer or String* | Yes | The id of the item to update (a number or a temp id).
-token *String* | Yes | The user's API token
 new_date_utc *String* | No | The date of the task in the format `YYYY-MM-DDTHH:MM` (for example: `2012-3-24T23:59`). The value of `new_date_utc` must be in UTC. Note that, when the `new_date_utc` argument is specified, the `date_string` is required and has to specified as well, and also, the `date_string` argument will be parsed as local timestamp, and converted to UTC internally, according to the user's profile settings.
 date_string  *String* | No | The date of the task, added in free form text, for example it can be `every day @ 10` (or `null` or an empty string to unset). Look at our reference to see [which formats are supported](https://todoist.com/Help/DatesTimes).
 is_forward  *Integer* | No | Whether the task is to be completed (value `1`) or uncompleted (value `0`), while the default is `1`.
@@ -336,12 +329,11 @@ does exactly what official clients do when you close a task: regular task is
 completed and moved to history, subtask is checked (marked as done, but not moved
 to history), recurring task is moved forward (due date is updated).
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer or String (temp id)* | Yes | The id of the item to close (a number or a temp id).
-token *String* | Yes | The user's API token
 
 
 ## Update multiple orders/indents
@@ -367,12 +359,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Update the orders and indents of multiple items at once.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 ids_to_orders_indents *Object* | Yes | A dictionary, where an item id is the key, and a list with two elements, the order and the indent, are its value: `item_id: [item_order, indent]`.
-token *String* | Yes | The user's API token
 
 
 ## Update day orders
@@ -398,9 +389,8 @@ $ curl https://todoist.com/api/v7/sync \
 
 Update the day orders of multiple items at once.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 ids_to_orders *Object* | Yes | A dictionary, where an item id is the key, and the day order its value: `item_id: day_order`.
-token *String* | Yes | The user's API token

--- a/source/includes/sync/v7/_labels.md
+++ b/source/includes/sync/v7/_labels.md
@@ -46,12 +46,11 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 name *String* | Yes | The name of the label
-token *String* | Yes | The user's API token
 color *Integer* | No | The color of the label (a number between `0` and `7`, or between `0` and `12` for premium users).
 item_order *Integer* | No | Label’s order in the label list (a number, where the smallest value should place the label at the top).
 
@@ -79,12 +78,11 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer or String (temp_id)* | Yes | The id of the label.
-token *String* | Yes | The user's API token
 name *String* | No | The name of the label.
 color *Integer* | No | The color of the label (a number between `0` and `7`, or between `0` and `12` for premium users).
 item_order *Integer* | No | Label’s order in the label list.
@@ -113,12 +111,11 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer or String (temp_id)* | Yes | The id of the label.
-token *String* | Yes | The user's API token
 
 ## Update multiple orders
 
@@ -146,9 +143,8 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id_order_mapping *Object* | Yes | A dictionary, where a label id is the key, and the order its value: `label_id: order`.
-token *String* | Yes | The user's API token

--- a/source/includes/sync/v7/_livenotifications.md
+++ b/source/includes/sync/v7/_livenotifications.md
@@ -374,12 +374,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Set the last known notification.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer* | Yes | The id of the last known notification (a number or `0` or `null` to mark all read).
-token *String* | Yes | The user's API token
 
 ## Mark as read
 
@@ -406,12 +405,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Mark the notification as read.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer* | Yes |  The id of the notification.
-token *String* | Yes | The user's API token
 
 ## Mark all as read
 
@@ -438,11 +436,6 @@ $ curl https://todoist.com/api/v7/sync \
 
 Mark all notifications as read.
 
-### Parameters
-
-Parameter | Required | Description
---------- | -------- | -----------
-token *String* | Yes | The user's API token
 
 ## Mark as unread
 
@@ -469,9 +462,8 @@ $ curl https://todoist.com/api/v7/sync \
 
 Mark the notification as unread.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer* | Yes | The id of the notification.
-token *String* | Yes | The user's API token

--- a/source/includes/sync/v7/_miscellaneous.md
+++ b/source/includes/sync/v7/_miscellaneous.md
@@ -127,11 +127,6 @@ $ curl https://todoist.com/api/v7/completed/get_stats \
 
 Get the user's productivity stats.
 
-### Parameters
-
-Parameter | Required | Description
---------- | -------- | -----------
-token *String* | Yes | The user's API token
 
 ## Get all completed items
 
@@ -207,7 +202,6 @@ Get all the user's completed items (tasks).
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 project_id *Integer* | No | Filter the tasks by project id.
 limit *Integer* | No | The number of items to return (where the default is `30`, and the maximum is `50`).
 offset *Integer* | No | Can be used for pagination, when more than the `limit` number of tasks are returned.
@@ -257,11 +251,6 @@ $ curl https://todoist.com/api/v7/projects/get_archived \
 
 Get the user's archived projects.
 
-### Parameters
-
-Parameter | Required | Description
---------- | -------- | -----------
-token *String* | Yes | The user's API token
 
 ## Add item
 
@@ -332,7 +321,6 @@ method, a shortcut, to quickly add a task without going through the
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 content *String* | Yes | The text of the task.
 project_id *Integer* | No | The id of the project to add the task to, while the default is the user's `Inbox` project.
 date_string *String* | No | The date of the task, added in free form text, for example it can be `every day @ 10` (or `null` or an empty string to unset). Look at our reference to see [which formats are supported](https://todoist.com/Help/DatesTimes).
@@ -524,7 +512,6 @@ and `notes` attributes.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 item_id *Integer* | Yes | The item's unique id.
 all_data *Boolean* | No | Whether to return the parent project and notes of the item (a `true` or `false` value, while the default is `true`).
 
@@ -610,7 +597,6 @@ It returns a JSON object with the `project`, and optionally the `notes` attribut
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 project_id *Integer* | Yes | The projects's unique id.
 all_data *Boolean* | No | Whether to return the notes of the project (a `true` or `false` value, while the default is `true`).
 
@@ -718,5 +704,4 @@ Get a project's uncompleted items.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 project_id *Integer* | Yes | The projects's unique id.

--- a/source/includes/sync/v7/_notes.md
+++ b/source/includes/sync/v7/_notes.md
@@ -105,13 +105,12 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 item_id *Integer* | Yes | The item which the note is part of (a unique number or temp id).
 content *String* | Yes | The content of the note (a string value).
-token *String* | Yes | The user's API token
 file_attachment *Object* | No | A file attached to the note (see more details about attachments above, and learn how to upload a file in the [Uploads section](#uploads)).
 uids_to_notify *Array of Integer* | No | A list of user ids to notify.
 
@@ -140,13 +139,12 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 project_id *Integer or String (temp_id)* | Yes | The project which the note is part of.
 content *String* | Yes | The content of the note.
-token *String* | Yes | The user's API token
 file_attachment *Object* | No | A file attached to the note (see more details about attachments above, and learn how to upload a file in the [Uploads section](#uploads)).
 
 ## Update a note
@@ -173,13 +171,12 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer or String (temp_id)* | Yes | The id of the note.
 content *String* | Yes | The content of the note.
-token *String* | Yes | The user's API token
 file_attachment *Object* | No | A file attached to the note (see more details about attachments above, and learn how to upload a file in the [Uploads section](#uploads)).
 
 ## Delete a note
@@ -203,9 +200,8 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer or String (temp_id)* | Yes | The id of the note.
-token *String* | Yes | The user's API token

--- a/source/includes/sync/v7/_projects.md
+++ b/source/includes/sync/v7/_projects.md
@@ -55,12 +55,11 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.commit()
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 name *String* | Yes | The name of the project (a string value).
-token *String* | Yes | The user's API token
 color *Integer* | No | The color of the project (a number between `0` and `11`, or between `0` and `21` for premium users).
 indent *Integer* | No | The indent of the item (a number between `1` and `4`, where `1` is top-level).
 item_order *Integer* | No | Project's order in the project list (a number, where the smallest value should place the project at the top).
@@ -90,12 +89,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Update an existing project.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id  *Integer or String (temp_id)* | Yes | The id of the project (could be temp id).
-token *String* | Yes | The user's API token
 name *String* | No | The name of the project (a string value).
 color *Integer* | No | The color of the project (a number between `0` and `11`, or between `0` and `21` for premium users).
 indent *Integer* | No | The indent of the item (a number between `1` and `4`, where `1` is top-level).
@@ -127,11 +125,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Delete an existing project.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 ids *Array of Integer (id) or String (temp id)* | Yes | List of the ids of the projects to delete (could be temp ids).
 
 
@@ -161,11 +158,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Archive project and its children.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 ids *Array of Integer (id) or String (temp id)* | Yes | List of the ids of the projects to archive (could be temp ids).
 
 ## Unarchive a project
@@ -194,11 +190,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Unarchive project and its children.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 ids  *Array of Integer (id) or String (temp id)* | Yes | List of the ids of the projects to unarchive (could be temp ids).
 
 ## Update multiple orders/indents
@@ -224,9 +219,8 @@ $ curl https://todoist.com/api/v7/sync \
 
 Update the orders and indents of multiple projects at once.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 ids_to_orders_indents *Object* | Yes | A dictionary object, with a project id as key and a two elements list as value: `project_id: [item_order, indent]`

--- a/source/includes/sync/v7/_quick.md
+++ b/source/includes/sync/v7/_quick.md
@@ -72,7 +72,6 @@ clients.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 text *String* | Yes | The text of the task that is parsed.  It can include a due date in free form text, a project name starting with the `#` character, a label starting with the `@` character, and an assignee starting with the `+` character.
 note *String* | No | The content of the note.
 reminder *String* | No | The date of the reminder, added in free form text.

--- a/source/includes/sync/v7/_reminders.md
+++ b/source/includes/sync/v7/_reminders.md
@@ -110,12 +110,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Add a new reminder to the user account related to the API credentials.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 item_id *Integer or String (temp_id)* | Yes | The item id for which the reminder is about.
-token *String* | Yes | The user's API token
 notify_uid *Integer* | No | The user id which should be notified of the reminder, typically the current user id creating the reminder.
 service *String* | No | The way to get notified of the reminder: `email` for e-mail, `mobile` for mobile text message, or `push` for mobile push notification.
 type *String* | No | The type of the reminder: `relative` for a time-based reminder specified in minutes from now, `absolute` for a time-based reminder with a specific time and date in the future, and `location` for a location-based reminder.
@@ -155,12 +154,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Update a reminder from the user account related to the API credentials.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 id *Integer or String (temp_id)* | Yes | The id of the reminder.
-token *String* | Yes | The user's API token
 notify_uid *Integer* | No | The user id which should be notified of the reminder, typically the current user id creating the reminder.
 service *String* | No | The way to get notified of the reminder: `email` for e-mail, `mobile` for mobile text message, or `push` for mobile push notification.
 type *String* | No | The type of the reminder: `relative` for a time-based reminder specified in minutes from now, `absolute` for a time-based reminder with a specific time and date in the future, and `location` for a location-based reminder.
@@ -200,11 +198,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Delete a reminder from the user account related to the API credentials.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 id *Integer or String (temp_id)* | Yes | The id of the filter.
 
 
@@ -230,9 +227,3 @@ $ curl https://todoist.com/api/v7/sync \
 ```
 
 Clears the locations list, which is used for the location reminders.
-
-### Parameters
-
-Parameter | Required | Description
---------- | -------- | -----------
-token *String* | Yes | The user's API token

--- a/source/includes/sync/v7/_sharing.md
+++ b/source/includes/sync/v7/_sharing.md
@@ -87,12 +87,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Share a project with another user.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 project_id *Integer or String (temp_id)* | Yes | The project to be shared.
-token *String* | Yes | The user's API token
 email *String* | Yes | The user email with whom to share the project.
 
 ## Delete a collaborator
@@ -120,12 +119,11 @@ $ curl https://todoist.com/api/v7/sync \
 
 Remove an user from a shared project.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
 project_id *Integer or String (temp_id)* | Yes | The project to be affected.
-token *String* | Yes | The user's API token
 email *String* | Yes | The user email with whom the project was shared with.
 
 ## Accept an invitation
@@ -153,11 +151,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Accept an invitation to join a shared project.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 invitation_id *Integer* | Yes | The invitation id.
 invitation_secret *String* | Yes | The secret fetched from the live notification.
 
@@ -186,11 +183,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Reject an invitation to join a shared project.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 invitation_id *Integer* | Yes | The invitation id.
 invitation_secret *String* | Yes | The secret fetched from the live notification.
 
@@ -219,9 +215,8 @@ $ curl https://todoist.com/api/v7/sync \
 
 Delete an invitation to join a shared project.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 invitation_id *Integer* | Yes | The invitation to be deleted.

--- a/source/includes/sync/v7/_uploads.md
+++ b/source/includes/sync/v7/_uploads.md
@@ -64,7 +64,6 @@ Upload a file suitable to be passed as a `file_attachment` attribute to the
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 file_name *String* | Yes | The file name to be uploaded.
 
 ### Base file properties
@@ -178,7 +177,6 @@ Get all user's uploads.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 limit *Integer* | No | The number of items to return (a number, where the default is `30`, and the maximum is `50`).
 last_id *Integer* | No | Can be used for pagination. This should be the minimum upload id you've fetched so far. All results will be listed before that id.
 
@@ -207,5 +205,4 @@ Delete an uploaded file.
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 file_url *String* | Yes | The file URL to delete.

--- a/source/includes/sync/v7/_user.md
+++ b/source/includes/sync/v7/_user.md
@@ -229,7 +229,6 @@ ok
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's token.
 current_password *String* | Yes | The user's current password.
 reason_for_delete *String* | No | A reason for deletion, that is used for sending feedback back to Todoist.
 
@@ -257,11 +256,10 @@ $ curl https://todoist.com/api/v7/sync \
 >>> api.user.update(time_format=0)
 ```
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 email *String* | No | The user's email.
 full_name *String* | No | The user's real name formatted as `Firstname Lastname`.
 password *String* | No | The user's password.
@@ -301,11 +299,10 @@ $ curl https://todoist.com/api/v7/sync \
 
 Update the karma goals of the user.
 
-### Parameters
+### Command arguments
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 daily_goal *Integer* | No | The target number of tasks to complete per day.
 weekly_goal *Integer* | No | The target number of tasks to complete per week.
 ignore_days *Integer* | No | A list with the days of the week to ignore (`1` for `Monday` and `7` for `Sunday`).
@@ -449,11 +446,10 @@ $ curl https://todoist.com/api/v7/notification_settings/update \
 
 Update the user's notification settings.
 
-### Required parameters
+### Parameters
 
 Parameter | Required | Description
 --------- | -------- | -----------
-token *String* | Yes | The user's API token
 notification_type *String* | Yes | The notification type.  For a list of notifications have a look at the `Live Notifications` section.
 service *String* | Yes | The service type, which can take the values: `email` or `push`.
 dont_notify *Integer* | Yes | Whether notifications of this service should be notified (`1` to not notify, and `0` to notify).


### PR DESCRIPTION
@stkao05 this is regarding our talk about the presence of the `token` argument on all resources. 

For the sync API the description of "Parameters" are related to the
command arguments, not API parameters.

This PR changes "Parameters" to "Command arguments" when it makes
sense and also removes token from every request. We added a not at the
the authorization section specifying that token is required
for **all** our resources.