### PR TITLE
Remove 'order' param from 'Update a task'

### DIFF
--- a/source/includes/rest/v8/_tasks.md
+++ b/source/includes/rest/v8/_tasks.md
@@ -303,7 +303,7 @@ Update a task and return an empty body with the HTTP status code 204
 Parameter | Required | Description
 --------- | -------- | -----------
 content *String* | Yes | Task content
-project_id *Integer* | No | Task project id. If not set, task is put to user's Inbox
+project_id *Integer* | No | Task project id
 label_ids *Array of Integers* | No | Ids of labels associated with the task
 priority *Integer* | No | Task priority from 1 (normal) to 4 (urgent)
 due_string *String* | No | [human-defined](https://todoist.com/Help/DatesTimes) task due date (ex.: "next Monday", "Tomorrow"). Value is set using local (not UTC) time.

--- a/source/includes/rest/v8/_tasks.md
+++ b/source/includes/rest/v8/_tasks.md
@@ -304,7 +304,6 @@ Parameter | Required | Description
 --------- | -------- | -----------
 content *String* | Yes | Task content
 project_id *Integer* | No | Task project id. If not set, task is put to user's Inbox
-order *Integer* | No | Non-zero integer value used by clients to sort tasks inside project
 label_ids *Array of Integers* | No | Ids of labels associated with the task
 priority *Integer* | No | Task priority from 1 (normal) to 4 (urgent)
 due_string *String* | No | [human-defined](https://todoist.com/Help/DatesTimes) task due date (ex.: "next Monday", "Tomorrow"). Value is set using local (not UTC) time.


### PR DESCRIPTION
The order parameter is read-only, and cannot be updated via the REST API. 

![screen shot 2017-08-16 at 2 46 49 pm](https://user-images.githubusercontent.com/3893573/29356400-c59f4440-8291-11e7-8819-acf2cbc4aa3c.png)

This is accurately mentioned in the description of a task object (above), but the 'Update a task' endpoint still has the parameter. 

**Before**

![screen shot 2017-08-16 at 2 48 19 pm](https://user-images.githubusercontent.com/3893573/29356486-1261fb1a-8292-11e7-900d-37cfceaae3ee.png)

**After**

![screen shot 2017-08-16 at 2 48 26 pm](https://user-images.githubusercontent.com/3893573/29356491-1389c20c-8292-11e7-9f6d-26df7b84cb46.png)